### PR TITLE
Upgrade postcss to version 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "condense-whitespace": "^1.0.0",
     "deasync": "^0.1.9",
-    "postcss": "^5.2.17",
+    "postcss": "^6.0.8",
     "postcss-load-config": "^1.2.0",
     "postcss-nesting": "^4.0.1",
     "string-hash": "^1.1.3"

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import { expect } from 'chai'
-import { jsdom } from 'jsdom'
+import { jsdom } from 'jsdom/lib/old-api'
 import { red, white, mobile, medium } from './support/theme'
 import { css, inject } from '../src'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,6 +61,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
+
 anymatch@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
@@ -746,6 +752,14 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
@@ -786,6 +800,16 @@ co@^4.6.0:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+color-convert@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
@@ -1445,6 +1469,10 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -1680,10 +1708,6 @@ jodid25519@^1.0.0:
   resolved "https://registry.yarnpkg.com/jodid25519/-/jodid25519-1.0.2.tgz#06d4912255093419477d425633606e0e90782967"
   dependencies:
     jsbn "~0.1.0"
-
-js-base64@^2.1.9:
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
 
 js-tokens@^3.0.0:
   version "3.0.1"
@@ -2175,15 +2199,6 @@ postcss-nesting@^4.0.1:
   dependencies:
     postcss "^6.0.1"
 
-postcss@^5.2.17:
-  version "5.2.17"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.17.tgz#cf4f597b864d65c8a492b2eabe9d706c879c388b"
-  dependencies:
-    chalk "^1.1.3"
-    js-base64 "^2.1.9"
-    source-map "^0.5.6"
-    supports-color "^3.2.3"
-
 postcss@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.1.tgz#000dbd1f8eef217aa368b9a212c5fc40b2a8f3f2"
@@ -2191,6 +2206,14 @@ postcss@^6.0.1:
     chalk "^1.1.3"
     source-map "^0.5.6"
     supports-color "^3.2.3"
+
+postcss@^6.0.8:
+  version "6.0.8"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.8.tgz#89067a9ce8b11f8a84cbc5117efc30419a0857b3"
+  dependencies:
+    chalk "^2.0.1"
+    source-map "^0.5.6"
+    supports-color "^4.2.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -2587,6 +2610,12 @@ supports-color@^3.2.3:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
+
+supports-color@^4.0.0, supports-color@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.1.tgz#65a4bb2631e90e02420dba5554c375a4754bb836"
+  dependencies:
+    has-flag "^2.0.0"
 
 symbol-tree@^3.2.1:
   version "3.2.2"


### PR DESCRIPTION
This PR upgrade _postcss_ to version 6 in order to resolve following errors.

I got these errors while building with _Webpack_.

```
Your current PostCSS version is 5.2.17, but postcss-nesting uses 6.0.8. Perhaps this is the source of the error below.

...

ERROR in .../style.js
Module build failed: .../style.js: node.parent.after is not a function
    at module.exports (.../node_modules/postcss-nesting/lib/transform-nesting-rule.js:18:29)
    at walk (.../node_modules/postcss-nesting/index.js:25:3)
```

I had to use old API for _jsdom_ to resolve this error.

```
  1) injected-css "before each" hook for "#css generates object with class names":
     TypeError: (0 , _jsdom.jsdom) is not a function
      at Context.beforeEach (test/index.js:9:23)
```

After all the changes I still get this error when running tests.

```
  1) injected-css #css generates object with class names:

      AssertionError: expected 'undefined' to equal 'c-test-button'
      + expected - actual

      -undefined
      +c-test-button
      
      at Context.it (test/index.js:58:31)
```

The `style` object looks like this (there are no attributes for CSS selectors).

```
{
  _css: '.c-test { text-align: center; &-button { background: #ff0000; width: 32rem; padding: 2rem; border-radius: 0.5rem; border: none; outline: none } &-button:hover { background: #fff; } &-button[disabled] { cursor: not-allowed; } } @media (max-width: 629px) { .c-test { &-button { width: 16rem } } } .c-test { &-button { &-icon { color: #ff0000; } &-text { color: #fff; } } &-logo { height: 1.6rem; width: 1.6rem } &-logo.is-large { height: 3.2rem; width: 3.2rem; } }',
  _hash: '3317473887-1',
  toString: [Function: toString]
}
```